### PR TITLE
Updated convert-source-map to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "coffee-script": ">= 1.6.0",
     "mkdirp": ">= 0.3.1",
-    "convert-source-map": "~0.2.5"
+    "convert-source-map": "~1.3.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
This newer version of convert-source-map uses `# sourceMappingURL=`.  When applied, this commit keeps the following warning from appearing in the console: 

`'//@ sourceURL' and '//@ sourceMappingURL' are deprecated, please use '//# sourceURL=' and '//# sourceMappingURL=' instead.`
